### PR TITLE
Set locale in oracle-java/jdk8

### DIFF
--- a/oracle-java/jdk-8/Dockerfile
+++ b/oracle-java/jdk-8/Dockerfile
@@ -7,6 +7,7 @@ ENV JAVA_VERSION 8
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
 RUN apt-get update \
+  && apt-get install -y locales \
   && apt-get -y install software-properties-common \
   && add-apt-repository ppa:webupd8team/java \
   && apt-get update \
@@ -17,3 +18,7 @@ RUN apt-get update \
   && rm -rf /var/cache/oracle-jdk${JAVA_VERSION}-installer \
   && update-java-alternatives -s java-8-oracle \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN apt-get install -y locales
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
Ubuntu locale defaults to `US-ASCII`, which can cause weird encoding bugs within Java.